### PR TITLE
Unique session name + more

### DIFF
--- a/lab-env-build/launch.py
+++ b/lab-env-build/launch.py
@@ -149,7 +149,6 @@ print("It is HIGHLY encouraged to allow this process to create the VPC and all c
 print("One reason to choose the option to use an existing VPC is if you require more than two (2) pods (which require a total of 4 EIPs),")
 print("in which case you will need to make a request to AWS to increase the number of EIPs and have them allocated to a specific VPC-Id PRIOR to running this script.")
 print("To deploy into an existing VPC, the VPC ID and the ID of the Internet Gateway in the existing VPC will be needed,")
-print("as well as requiring the two (2) subnets chosen in the parameters.yml file to be associated to the VPC as attached CIDR Blocks.")
 print(" ")
 print("Again, unless you require more than 2 pods to be deployed, you should allow this script to create everything for you.")
 print(" ")

--- a/lab-env-build/n0work-pod-cft-template.yml
+++ b/lab-env-build/n0work-pod-cft-template.yml
@@ -1302,6 +1302,18 @@ Resources:
           sh -c 'cd /opt && git clone https://github.com/deftcon/TVB-assets'
           cp /opt/TVB-assets/ansible_ping.sh /home/ciscolab/
           (crontab -l 2>/dev/null; echo "* * * * * /bin/sh /home/ciscolab/ansible_ping.sh >> /home/ciscolab/ansible_ping.log") | crontab -
+          cat <<EOF > /opt/TVB-assets/iis-healthcheck/hosts
+          [iis]
+          ${n0workEC2IIS.PrivateIp}
+          [iis:vars]
+          ansible_user=HOL\ciscolab
+          ansible_password=tet123\$\$!
+          ansible_connection=winrm
+          ansible_winrm_transport=ntlm
+          ansible_winrm_server_cert_validation=ignore
+          validate_certs=false
+          EOF
+          (crontab -l 2>/dev/null; echo "* * * * * ansible-playbook /opt/TVB-assets/iis-healthcheck/check_iis.yml -i /opt/TVB-assets/iis-healthcheck/hosts >> /home/ciscolab/ansible_iis_healthcheck.log") | crontab -
           cat <<EOF > /opt/TVB-assets/tvb-agent/inventory/hosts
           [centos]
           ${n0workEC2Apache.PrivateIp}

--- a/lab-env-build/n0work-pod-cft-template.yml
+++ b/lab-env-build/n0work-pod-cft-template.yml
@@ -1653,7 +1653,7 @@ Resources:
       Role: !Sub ${LambdaExecutionRole.Arn}
       Environment:
         Variables:
-          APP_URL: !Sub ${SessionName}-${PodName}-nopcommerce.lab.tetration.guru
+          APP_URL: !Sub ${SessionName}-${PodName}-nopcommerce-iis.lab.tetration.guru
       Runtime: nodejs12.x
 
   LambdaScheduleIIS:
@@ -1705,7 +1705,7 @@ Resources:
       Role: !Sub ${LambdaExecutionRole.Arn}
       Environment:
         Variables:
-          APP_URL: !Sub ${SessionName}-${PodName}-opencart.lab.tetration.guru
+          APP_URL: !Sub ${SessionName}-${PodName}-opencart-apache.lab.tetration.guru
       Runtime: nodejs12.x
 
   LambdaScheduleApache:
@@ -1842,7 +1842,6 @@ Outputs:
   n0workASAvPrivate03:
     Description: ASAv Firewall Inside IP Address
     Value: !GetAtt ASAvNetworkInterfaces03.PrimaryPrivateIpAddress
-
   n0workActiveDirectory:
     Description: Active Directory Server Private IP
     Value: !GetAtt n0workEC2ActiveDirectory.PrivateIp
@@ -1900,3 +1899,6 @@ Outputs:
   n0workGuacamolePublic:
     Description: Guacamole Server Public IP
     Value: !Ref GuacamoleElasticIp
+  n0workGuacamoleDNS:
+    Description: Guacamole Server Public DNS
+    Value: !Sub ${SessionName}-${PodName}-guac-pod-ui.lab.tetration.guru

--- a/lab-env-build/n0work-pod-cft-template.yml
+++ b/lab-env-build/n0work-pod-cft-template.yml
@@ -1302,7 +1302,7 @@ Resources:
           sh -c 'cd /opt && git clone https://github.com/deftcon/TVB-assets'
           cp /opt/TVB-assets/ansible_ping.sh /home/ciscolab/
           (crontab -l 2>/dev/null; echo "* * * * * /bin/sh /home/ciscolab/ansible_ping.sh >> /home/ciscolab/ansible_ping.log") | crontab -
-          cat <<EOF > /opt/TVB-assets/iis-healthcheck/hosts
+          cat <<EOF > /opt/TVB-assets/iis_healthcheck/hosts
           [iis]
           ${n0workEC2IIS.PrivateIp}
           [iis:vars]
@@ -1313,7 +1313,7 @@ Resources:
           ansible_winrm_server_cert_validation=ignore
           validate_certs=false
           EOF
-          (crontab -l 2>/dev/null; echo "* * * * * ansible-playbook /opt/TVB-assets/iis-healthcheck/check_iis.yml -i /opt/TVB-assets/iis-healthcheck/hosts >> /home/ciscolab/ansible_iis_healthcheck.log") | crontab -
+          (crontab -l 2>/dev/null; echo "* * * * * ansible-playbook /opt/TVB-assets/iis_healthcheck/check_iis.yml -i /opt/TVB-assets/iis_healthcheck/hosts >> /home/ciscolab/ansible_iis_healthcheck.log") | crontab -
           cat <<EOF > /opt/TVB-assets/tvb-agent/inventory/hosts
           [centos]
           ${n0workEC2Apache.PrivateIp}

--- a/lab-env-build/n0work-pod-cft-template.yml
+++ b/lab-env-build/n0work-pod-cft-template.yml
@@ -405,6 +405,7 @@ Resources:
         - Key: AppSDLC
           Value: Lab
 
+
   n0workWebSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
@@ -470,6 +471,8 @@ Resources:
           Value: !Sub ${ScheduleName}
         - Key: Pod
           Value: !Sub ${PodName}
+        - Key: DNS
+          Value: !Sub ${SessionName}-${PodName}-microsoft-ad-dc.lab.tetration.guru
       UserData:
         Fn::Base64: !Sub |
           <powershell>
@@ -525,6 +528,8 @@ Resources:
           Value: !Sub ${ScheduleName}
         - Key: Pod
           Value: !Sub ${PodName}
+        - Key: DNS
+          Value: !Sub ${SessionName}-${PodName}-nopcommerce-mssql.lab.tetration.guru
       UserData:
         Fn::Base64: !Sub |
           <powershell>
@@ -575,7 +580,7 @@ Resources:
         - Key: Pod
           Value: !Sub ${PodName}
         - Key: DNS
-          Value: !Sub ${SessionName}-${PodName}-nopcommerce.lab.tetration.guru
+          Value: !Sub ${SessionName}-${PodName}-nopcommerce-iis.lab.tetration.guru
       UserData:
         Fn::Base64: !Sub |
           <powershell>
@@ -633,6 +638,8 @@ Resources:
           Value: !Sub ${ScheduleName}
         - Key: Pod
           Value: !Sub ${PodName}
+        - Key: DNS
+          Value: !Sub ${SessionName}-${PodName}-opencart-mysql.lab.tetration.guru
       UserData:
         Fn::Base64: !Sub |
           #!/bin/bash
@@ -681,7 +688,7 @@ Resources:
         - Key: Pod
           Value: !Sub ${PodName}
         - Key: DNS
-          Value: !Sub ${SessionName}-${PodName}-opencart.lab.tetration.guru
+          Value: !Sub ${SessionName}-${PodName}-opencart-apache.lab.tetration.guru
       UserData:
         Fn::Base64: !Sub |
           #!/bin/bash
@@ -831,6 +838,8 @@ Resources:
           Value: !Sub ${ScheduleName}
         - Key: Pod
           Value: !Sub ${PodName}
+        - Key: DNS
+          Value: !Sub ${SessionName}-${PodName}-user-employee.lab.tetration.guru
       UserData:
         Fn::Base64: !Sub |
           !/bin/bash
@@ -858,6 +867,8 @@ Resources:
           Value: !Sub ${ScheduleName}
         - Key: Pod
           Value: !Sub ${PodName}
+        - Key: DNS
+          Value: !Sub ${SessionName}-${PodName}-user-sysadmin.lab.tetration.guru
       UserData:
         Fn::Base64: !Sub |
           !/bin/bash
@@ -883,6 +894,8 @@ Resources:
           Value: !Sub "${SessionName}-${PodName}-bad-guy"
         - Key: Schedule
           Value: !Sub ${ScheduleName}
+        - Key: DNS
+          Value: !Sub ${SessionName}-${PodName}-bad-guy.lab.tetration.guru
       UserData:
         Fn::Base64: !Sub |
           !/bin/bash
@@ -1258,7 +1271,7 @@ Resources:
       InstanceType: t2.micro
       Tags:
         - Key: Name
-          Value: !Sub "${SessionName}-${PodName}-ansible"
+          Value: !Sub "${SessionName}-${PodName}-rh-ansible"
         - Key: Org
           Value: Tetration
         - Key: Geo
@@ -1279,6 +1292,8 @@ Resources:
           Value: !Sub ${ScheduleName}
         - Key: Pod
           Value: !Sub ${PodName}
+        - Key: DNS
+          Value: !Sub ${SessionName}-${PodName}-rh-ansible.lab.tetration.guru
       UserData:
         Fn::Base64: !Sub |
           #!/bin/bash
@@ -1421,6 +1436,8 @@ Resources:
           Value: !Sub ${PodName}
         - Key: Schedule
           Value: !Sub ${ScheduleName}
+        - Key: DNS
+          Value: !Sub ${SessionName}-${PodName}-guac-pod-ui.lab.tetration.guru
         
       UserData:
         Fn::Base64: !Sub |
@@ -1837,7 +1854,7 @@ Outputs:
     Value: !GetAtt n0workEC2IIS.PrivateIp
   n0workIISDNS:
     Description: IIS Server DNS Name
-    Value: !Sub ${SessionName}-${PodName}-nopcommerce.lab.tetration.guru
+    Value: !Sub ${SessionName}-${PodName}-nopcommerce-iis.lab.tetration.guru
   n0workIISOutsidePrivate:
     Description: IIS Server Outside Private IP
     Value: !Ref IISOutsidePrivateIp
@@ -1849,7 +1866,7 @@ Outputs:
     Value: !GetAtt n0workEC2Apache.PrivateIp
   n0workApacheDNS:
     Description: Apache Server DNS Name
-    Value: !Sub ${SessionName}-${PodName}-opencart.lab.tetration.guru
+    Value: !Sub ${SessionName}-${PodName}-opencart-apache.lab.tetration.guru
   n0workApacheOutsidePrivate:
     Description: Apache Server Outside Private IP
     Value: !Ref ApacheOutsidePrivateIp

--- a/lab-env-build/n0work-scheduler-cft-template.yml
+++ b/lab-env-build/n0work-scheduler-cft-template.yml
@@ -618,7 +618,7 @@ Parameters:
       name=value,name=value,.. that are set on stopped instances
   SchedulerFrequency:
     Type: String
-    Default: '5'
+    Default: '1'
     AllowedValues:
       - '1'
       - '2'

--- a/lab-env-build/rollback.py
+++ b/lab-env-build/rollback.py
@@ -508,4 +508,19 @@ try:
 except Exception as e:
     print(f'WARN: While deleting {STATE_FILE} from S3:  {e}')
 
+########################################################################
+# Delete the DNS record for the session from Route53
+########################################################################
+print(f"INFO: Deleting {SESSION_NAME}.lab.tetration.guru from Route53")
+resp = update_dns("127.0.0.1", f"{SESSION_NAME}.lab.tetration.guru")
+if resp.status_code == 200:
+    content = json.loads(resp.content)
+    if content:
+        if "return_message" in content:
+            print(f"INFO: Response from API - {content['return_message']}")
+        else:
+            print(f"WARN: {content['errorMessage']}")
+    else:
+        print(f"ERROR: Received HTTP {resp.status_code} {resp.reason}")
+
 print('INFO: Rollback completed successfully!')

--- a/lab-env-build/rollback.py
+++ b/lab-env-build/rollback.py
@@ -199,7 +199,7 @@ else:
 #######################################################################
 # EIP de-association and un-allocation + DynDNS deletion
 #######################################################################
-def update_dns(public_ip, hostname):
+def delete_dns(public_ip, hostname):
     '''Your friendly neighborhood DNS cleaner upper'''
     api_key = API_GATEWAY_KEY
     api_url = API_GATEWAY_URL
@@ -251,7 +251,7 @@ for pod in PODS_LIST:
                                 hostname = tag['Value']
                                 if public_ip:
                                     print(f'INFO: Deleting DNS entry for hostname: {hostname} IP Address: {public_ip}')
-                                    response = update_dns(public_ip, hostname)
+                                    response = delete_dns(public_ip, hostname)
                                     if response.status_code == 200:
                                         print(f'INFO: DNS update successful')
                                     else:
@@ -362,7 +362,7 @@ except Exception as e:
 print(f"INFO: Deleted class schedule n0work-{SESSION_NAME}-class-schedule")
 
 #######################################################################
-# Delete DynDNS Updater
+# Delete DynDNS Updater and associated S3 bucket
 #######################################################################
 print(f'INFO: Deleting the DNS updater Lambda function n0work-{SESSION_NAME}-dns-updater')
 try:
@@ -374,6 +374,17 @@ try:
 except Exception as e:
     print('WARN: ', e)
 print(f"INFO: Deleted DNS updater Lambda function n0work-{SESSION_NAME}-dns-updater")
+
+bucket_name = f"n0work-{SESSION_NAME}-lambda"
+s3 = session.resource('s3')
+bucket = s3.Bucket(bucket_name)
+print(f"INFO: Emptying s3 bucket {bucket_name}")
+bucket.objects.delete()
+while len(list(bucket.objects.iterator())) > 0:
+    print('INFO: Waiting for object deletion to complete')
+print(f"INFO: Deleting s3 bucket {bucket_name}")
+bucket.delete()
+print(f'INFO: S3 Bucket Deleted: {bucket_name}')
 
 #######################################################################
 # Delete Pods In CloudFormation ###############################
@@ -512,7 +523,7 @@ except Exception as e:
 # Delete the DNS record for the session from Route53
 ########################################################################
 print(f"INFO: Deleting {SESSION_NAME}.lab.tetration.guru from Route53")
-resp = update_dns("127.0.0.1", f"{SESSION_NAME}.lab.tetration.guru")
+resp = delete_dns("127.0.0.1", f"{SESSION_NAME}.lab.tetration.guru")
 if resp.status_code == 200:
     content = json.loads(resp.content)
     if content:
@@ -522,5 +533,62 @@ if resp.status_code == 200:
             print(f"WARN: {content['errorMessage']}")
     else:
         print(f"ERROR: Received HTTP {resp.status_code} {resp.reason}")
+
+########################################################################
+# Delete Sock Shop DNS record(s) from Route53
+########################################################################
+for pod in PODS_LIST:
+    print(f"INFO: Retrieving IP address for {SESSION_NAME}-{pod['account_name']}-sock-shop.lab.tetration.guru")
+    public_ip = None
+    resp = query_dns(f"{SESSION_NAME}-{pod['account_name']}-sock-shop.lab.tetration.guru")
+    if resp.status_code == 200:
+        if 'return_message' in json.loads(resp.content):
+            public_ip = json.loads(resp.content)['return_message']
+    if public_ip:
+        print(f"INFO Deleting DNS entry from Route 53 for {SESSION_NAME}-{pod['account_name']}-sock-shop.lab.tetration.guru")
+        resp = delete_dns(public_ip, f"{SESSION_NAME}-{pod['account_name']}-sock-shop.lab.tetration.guru")
+        if resp.status_code == 200:
+            if 'return_message' in json.loads(resp.content):
+                print(f"INFO: {json.loads(resp.content)['return_message']}")
+
+########################################################################
+# If no more active sessions, delete the scheduler 
+########################################################################
+# Below is to delete the S3 Bucket but the files with the AMI IDs also get deleted
+# then on the next run, the program will try to create new AMIs and will fail
+# unless the existing are deleted (manually).  Possibly we should prompt the 
+# user asking if they want to delete AMIs, and if so then we can delete both
+# the AMIs and the bucket.  
+# bucket = s3.Bucket(name=S3_BUCKET)
+# state_objects = [x for x in list(bucket.objects.iterator()) if 'state' in x.key]
+# if not state_objects:
+#     print(f"INFO: No more sessions found, S3 bucket and scheuler will be deleted")
+#     print(f"INFO: Emptying S3 bucket {S3_BUCKET}")
+#     bucket.objects.delete()
+#     while len(list(bucket.objects.iterator())) > 0:
+#         print('INFO: Waiting for object deletion to complete')
+#     print(f"INFO: Deleting s3 bucket {bucket_name}")
+#     bucket.delete()
+#     print(f'INFO: S3 Bucket Deleted: {bucket_name}')
+
+    cloudformation = session.client('cloudformation')
+    print(f"INFO: Stack deletion initiated for: n0work-instance-scheduler...")
+    try:  
+        result = cloudformation.delete_stack(
+            StackName=f"n0work-instance-scheduler"
+        )
+        while True:
+            try:
+                status = cloudformation.describe_stacks(
+                    StackName="n0work-instance-scheduler"
+                )
+                print(f"INFO: CFT n0work-instance-scheduler {status['Stacks'][0]['StackStatus']}")
+                time.sleep(5)
+            except:
+                print(f'INFO: Stack n0work-instance-scheduler was deleted...')
+                break
+    except Exception as e:
+        print('WARN: ', e)
+
 
 print('INFO: Rollback completed successfully!')


### PR DESCRIPTION
- Enters the session name in Route53 as an A record in the format {session_name}.lab.tetration.guru
- launch.py checks for the session name in Route53 to make sure it isn't already in use 
- fixed an issue where the dns-updater lambda CFT failed to create.  When using an S3 bucket to store the code for a lambda function,  the bucket must be in the same region as the function.  Created a new bucket in the same region to deal with this. 
- add all instance public IP addresses and hostnames to Route53
- add DNS entry for sock shop
- Updated Guacamole URL to point to DNS name in report
- Updated sock-show URL to point to DNS name in report
- changed scheduler frequency from 5 minutes to 1 minute
- Delete the scheduler from the account if no more sessions are present